### PR TITLE
Implement Tool Fetch API and Display Tools on Frontend

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "java.compile.nullAnalysis.mode": "automatic",
-    "java.debug.settings.onBuildFailureProceed": true
+    "java.debug.settings.onBuildFailureProceed": true,
+    "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Config/SecurityConfig.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Config/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
                 .requestMatchers(HttpMethod.GET,"/api/tools/getTools").permitAll() // Allow access to tools API
+                .requestMatchers("/api/payment/**", "/api/rental/**", "/api/tools/**").permitAll()
                 .anyRequest().authenticated()
             );
         return http.build();

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Controller/RentalController.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Controller/RentalController.java
@@ -1,0 +1,33 @@
+package com.project.toolbox.Controller;
+
+import com.project.toolbox.Model.Rental;
+import com.project.toolbox.Service.RentalService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/rental")
+@CrossOrigin(origins = "http://localhost:3000")
+public class RentalController {
+
+    @Autowired
+    private RentalService rentalService;
+
+    @PostMapping("/create")
+    public ResponseEntity<String> createRental(@RequestBody RentalRequest request) {
+        rentalService.createRental(request);
+        return ResponseEntity.ok("Rental saved successfully");
+    }
+
+    public static class RentalRequest {
+        public Long userId;
+        public Long toolId;
+        public String startDate;
+        public String endDate;
+        public Double amount;
+    }
+}

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Controller/ToolController.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Controller/ToolController.java
@@ -2,7 +2,6 @@ package com.project.toolbox.Controller;
 
 import com.project.toolbox.Model.Tool;
 import com.project.toolbox.Service.ToolServiceImpl;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,5 +29,10 @@ public class ToolController {
         } else {
             return ResponseEntity.notFound().build();
         }
+    }
+
+    @GetMapping("/search")
+    public List<Tool> searchTools(@RequestParam String keyword) {
+        return toolService.searchTools(keyword);
     }
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Controller/ToolController.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Controller/ToolController.java
@@ -1,28 +1,34 @@
 package com.project.toolbox.Controller;
 
 import com.project.toolbox.Model.Tool;
-import com.project.toolbox.Service.ToolService;
 import com.project.toolbox.Service.ToolServiceImpl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/tools")
-@CrossOrigin(origins = "*") // Enable CORS for frontend
+@CrossOrigin(origins = "*")
 public class ToolController {
-
-    // @Autowired
-    // private ToolService toolService;
 
     @Autowired
     private ToolServiceImpl toolService;
 
     @GetMapping("/getTools")
     public List<Tool> getAllTools() {
-        // return toolService.getAllTools();
         return toolService.getAllTools();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Tool> getToolById(@PathVariable Long id) {
+        Tool tool = toolService.getToolById(id);
+        if (tool != null) {
+            return ResponseEntity.ok(tool);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Model/Notification.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Model/Notification.java
@@ -1,0 +1,61 @@
+package com.project.toolbox.Model;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) 
+    private Long id; 
+    
+    @ManyToOne 
+    private User user; 
+    
+    private String message; 
+    private Boolean isRead; 
+    private LocalDateTime createdAt;
+    public Notification(Long id, User user, String message, Boolean isRead, LocalDateTime createdAt) {
+        this.id = id;
+        this.user = user;
+        this.message = message;
+        this.isRead = isRead;
+        this.createdAt = createdAt;
+    }
+    public Long getId() {
+        return id;
+    }
+    public void setId(Long id) {
+        this.id = id;
+    }
+    public User getUser() {
+        return user;
+    }
+    public void setUser(User user) {
+        this.user = user;
+    }
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    public Boolean getIsRead() {
+        return isRead;
+    }
+    public void setIsRead(Boolean isRead) {
+        this.isRead = isRead;
+    }
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+}

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Model/Rental.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Model/Rental.java
@@ -35,7 +35,8 @@ public class Rental {
 
     private LocalDateTime createdAt;
 
-    
+    public Rental() {
+} 
     public Rental(Long id, User user, Tool tool, LocalDate startDate, LocalDate endDate, BigDecimal totalAmount,
             RentalStatus status, LocalDateTime createdAt) {
         this.id = id;

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Model/Review.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Model/Review.java
@@ -1,0 +1,75 @@
+package com.project.toolbox.Model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "reviews")
+
+public class Review {
+@Id
+@GeneratedValue(strategy = GenerationType.IDENTITY) 
+private Long id; 
+
+@ManyToOne
+private User user;
+
+@ManyToOne 
+private Tool tool; 
+
+private Integer rating; 
+private String comment; 
+private LocalDateTime createdAt;
+public Review(Long id, User user, Tool tool, Integer rating, String comment, LocalDateTime createdAt) {
+    this.id = id;
+    this.user = user;
+    this.tool = tool;
+    this.rating = rating;
+    this.comment = comment;
+    this.createdAt = createdAt;
+}
+public Long getId() {
+    return id;
+}
+public void setId(Long id) {
+    this.id = id;
+}
+public User getUser() {
+    return user;
+}
+public void setUser(User user) {
+    this.user = user;
+}
+public Tool getTool() {
+    return tool;
+}
+public void setTool(Tool tool) {
+    this.tool = tool;
+}
+public Integer getRating() {
+    return rating;
+}
+public void setRating(Integer rating) {
+    this.rating = rating;
+}
+public String getComment() {
+    return comment;
+}
+public void setComment(String comment) {
+    this.comment = comment;
+}
+public LocalDateTime getCreatedAt() {
+    return createdAt;
+}
+public void setCreatedAt(LocalDateTime createdAt) {
+    this.createdAt = createdAt;
+}
+
+
+}

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Model/User.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Model/User.java
@@ -30,6 +30,9 @@ public class User {
 
     private LocalDateTime createdAt;
 
+    public User(){
+        
+    }
     // --- Getters and Setters ---
 
     public Long getId() {

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Repository/RentalRepository.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Repository/RentalRepository.java
@@ -1,0 +1,7 @@
+package com.project.toolbox.Repository;
+
+import com.project.toolbox.Model.Rental;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RentalRepository extends JpaRepository<Rental, Long> {
+}

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Repository/ToolRepository.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Repository/ToolRepository.java
@@ -3,6 +3,8 @@ package com.project.toolbox.Repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.project.toolbox.Model.Tool;
 
+import java.util.List;
+
 public interface ToolRepository extends JpaRepository<Tool, Long> {
-    
+    List<Tool> findByNameContainingIgnoreCase(String keyword);
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Service/RentalService.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Service/RentalService.java
@@ -1,0 +1,38 @@
+package com.project.toolbox.Service;
+
+import com.project.toolbox.Controller.RentalController.RentalRequest;
+import com.project.toolbox.Model.*;
+import com.project.toolbox.Repository.RentalRepository;
+import com.project.toolbox.Repository.ToolRepository;
+import com.project.toolbox.Repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class RentalService {
+
+    @Autowired
+    private RentalRepository rentalRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ToolRepository toolRepository;
+
+    public void createRental(RentalRequest request) {
+        Rental rental = new Rental(null, null, null, null, null, null, null, null);
+        rental.setUser(userRepository.findById(request.userId).orElseThrow());
+        rental.setTool(toolRepository.findById(request.toolId).orElseThrow());
+        rental.setStartDate(LocalDate.parse(request.startDate));
+        rental.setEndDate(LocalDate.parse(request.endDate));
+        rental.setTotalAmount(BigDecimal.valueOf(request.amount));
+        rental.setStatus(RentalStatus.CONFIRMED);
+        rental.setCreatedAt(LocalDateTime.now());
+        rentalRepository.save(rental);
+    }
+}

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolService.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolService.java
@@ -6,4 +6,6 @@ import com.project.toolbox.Model.Tool;
 public interface ToolService {
     List<Tool> getAllTools();
     Tool getToolById(Long id); // ✅ Add this
+    List<Tool> searchTools(String keyword);
+
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolService.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolService.java
@@ -5,4 +5,5 @@ import com.project.toolbox.Model.Tool;
 
 public interface ToolService {
     List<Tool> getAllTools();
+    Tool getToolById(Long id); // ✅ Add this
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolServiceImpl.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolServiceImpl.java
@@ -8,13 +8,19 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
-public class ToolServiceImpl {
+public class ToolServiceImpl implements ToolService {
 
     @Autowired
     private ToolRepository toolRepository;
 
+    @Override
     public List<Tool> getAllTools() {
         System.out.println("done");
         return toolRepository.findAll();
+    }
+
+    @Override
+    public Tool getToolById(Long id) {
+        return toolRepository.findById(id).orElse(null);
     }
 }

--- a/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolServiceImpl.java
+++ b/Backend/toolbox/src/main/java/com/project/toolbox/Service/ToolServiceImpl.java
@@ -15,12 +15,16 @@ public class ToolServiceImpl implements ToolService {
 
     @Override
     public List<Tool> getAllTools() {
-        System.out.println("done");
         return toolRepository.findAll();
     }
 
     @Override
     public Tool getToolById(Long id) {
         return toolRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public List<Tool> searchTools(String keyword) {
+        return toolRepository.findByNameContainingIgnoreCase(keyword);
     }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import About from './pages/aboutus';
 import Contact from './pages/contact';
 import Login from './pages/login';
 import Register from './pages/register';
+import Rent from './pages/Rent';
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
             <Route path="/contact" element={<Contact />} /> 
             <Route path="/login" element={<Login />} /> 
             <Route path="/register" element={<Register />} /> 
+            <Route path="/rent/:id" element={<Rent />} />
             {/* Add more routes as needed */}
           </Routes>
         </div>

--- a/frontend/src/pages/Rent.js
+++ b/frontend/src/pages/Rent.js
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+
+const Rent = () => {
+  const { id } = useParams();
+  const [tool, setTool] = useState(null);
+  const [fromDate, setFromDate] = useState('');
+  const [toDate, setToDate] = useState('');
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const currentUserId = 1; // Simulated user ID
+
+  useEffect(() => {
+    axios.get(`http://localhost:8080/api/tools/${id}`)
+      .then(response => {
+        setTool(response.data);
+      })
+      .catch(error => {
+        console.error("Error fetching tool:", error);
+        alert('❌ Tool not found!');
+      });
+  }, [id]);
+
+  useEffect(() => {
+    if (tool && fromDate && toDate && new Date(toDate) >= new Date(fromDate)) {
+      const start = new Date(fromDate);
+      const end = new Date(toDate);
+      const days = Math.ceil((end - start) / (1000 * 60 * 60 * 24)) + 1;
+      setTotalPrice(days * tool.pricePerDay);
+    } else {
+      setTotalPrice(0);
+    }
+  }, [fromDate, toDate, tool]);
+
+  const handleConfirm = async () => {
+    if (!fromDate || !toDate) {
+      alert('❗ Please select both From and To dates.');
+      return;
+    }
+    if (new Date(toDate) < new Date(fromDate)) {
+      alert('❗ To date cannot be earlier than From date.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await axios.post('http://localhost:8080/api/rental/create', {
+        userId: currentUserId,
+        toolId: tool.id,
+        startDate: fromDate,
+        endDate: toDate,
+        amount: totalPrice
+      });
+
+      alert('✅ Rental successfully saved to database!');
+      setFromDate('');
+      setToDate('');
+    } catch (error) {
+      console.error('Error:', error);
+      alert('❌ Failed to rent tool.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!tool) return <p style={{ padding: '20px' }}>Loading tool data...</p>;
+
+  return (
+    <div style={{
+      padding: '20px',
+      maxWidth: '1000px',
+      margin: '0 auto',
+      display: 'flex',
+      flexDirection: 'row',
+      gap: '30px',
+      alignItems: 'flex-start',
+      height: '90vh',
+    }}>
+      <div style={{ flex: '1' }}>
+        <h2>Rent: {tool.name}</h2>
+        <img
+          src={tool.imageUrl}
+          alt={tool.name}
+          style={{ width: '100%', maxHeight: '250px', objectFit: 'contain', borderRadius: '8px' }}
+        />
+        <p><strong>Price per Day:</strong> Rs. {tool.pricePerDay}</p>
+        <p><strong>Total Price:</strong> Rs. {totalPrice}</p>
+      </div>
+      <div style={{ flex: '1' }}>
+        <label>From Date:</label><br />
+        <input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} /><br /><br />
+        <label>To Date:</label><br />
+        <input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} /><br /><br />
+        <button
+          onClick={handleConfirm}
+          disabled={loading}
+          style={{
+            padding: '10px 20px',
+            backgroundColor: loading ? '#999' : '#282c34',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            cursor: loading ? 'not-allowed' : 'pointer'
+          }}
+        >
+          {loading ? 'Processing...' : 'Confirm Rent'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Rent;

--- a/frontend/src/pages/tools.js
+++ b/frontend/src/pages/tools.js
@@ -1,19 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 const Tool = () => {
   const [tools, setTools] = useState([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     axios.get('http://localhost:8080/api/tools/getTools')
       .then(response => {
-        console.log(response);
         setTools(response.data);
       })
       .catch(error => {
         console.error("Error fetching tools:", error);
       });
   }, []);
+
+  const handleRentClick = (id) => {
+    navigate(`/rent/${id}`);
+  };
 
   return (
     <div style={{ padding: '20px' }}>
@@ -36,7 +41,7 @@ const Tool = () => {
             />
             <h2>{tool.name}</h2>
             <p>Rs. {tool.pricePerDay}/day</p>
-            <button style={{ padding: '10px', backgroundColor: '#282c34', color: 'white', border: 'none', borderRadius: '4px' }}>
+            <button onClick={() => handleRentClick(tool.id)} style={{ padding: '10px', backgroundColor: '#282c34', color: 'white', border: 'none', borderRadius: '4px' }}>
               Rent Now
             </button>
           </div>


### PR DESCRIPTION
This pull request implements the functionality to fetch tool data from the  backend and display it on the  frontend.

### Backend Changes:
- Created `ToolController` with `/api/tools/getTools` endpoint.
- Added `ToolService` interface and `ToolServiceImpl` class.
- Connected to `ToolRepository` using Spring Data JPA to fetch all tools.

### Frontend Changes:
- Used Axios to call `http://localhost:8080/api/tools/getTools`.
- Fetched tool list on component mount (`useEffect`) and stored in React state.
- Displayed tool image, name, price, and "Rent Now" button.
